### PR TITLE
Minor fix: docker build image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ benchmark/*txt
 baselines/openhands/config.toml
 curie/tests/test_claude.py
 curie/setup/env*.sh
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ baselines/openhands/config.toml
 curie/tests/test_claude.py
 curie/setup/env*.sh
 *.DS_Store
+*.vscode/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ export OPENAI_API_KEY="sk-xxx"
 
 ```bash
 pip install -e .
+docker images -q exp-agent-image | xargs -r docker rmi -f # remove any existing conflict image
 cd curie && docker build --no-cache --progress=plain -t exp-agent-image -f ExpDockerfile_default .. && cd -
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ export OPENAI_API_KEY="sk-xxx"
 4. Build the container image. This will take a few minutes. Note: you may need to setup a virtual environment before running pip install.
 
 ```bash
+python -m venv cuire/venv
 pip install -e .
 cd curie && docker build --no-cache --progress=plain -t exp-agent-image -f ExpDockerfile_default .. && cd -
 ```
@@ -57,8 +58,8 @@ Use the following command to input your research question or problem statement: 
 ```bash
 python3 -m curie.main \
   -q "How does the choice of sorting algorithm impact runtime performance across different \
-  input distributions (random, nearly sorted, reverse sorted)? --report"
-``` 
+  input distributions (random, nearly sorted, reverse sorted)?" --report
+```
 
 - **Estimated runtime**: ~10 minutes
 - **Sample log file**: Available [here](./docs/example_logs/research_sorting_efficiency_20250306.log)
@@ -96,7 +97,7 @@ Curie is designed for scientific discovery across multiple domains:
   - [What configurations affects the energy consumption of LLM serving?](https://ml.energy/leaderboard/?__theme=light)
   - [How does the request bursty arrival pattern affects the user experience in LLM serving?](https://arxiv.org/abs/2404.16283)
 - 🧪 Algorithmic & Scientific Discovery – Validating hypotheses, automating computational simulations.
- 
+
 <p align="center">
   <img src="./docs/static/img/case_study.png" width="1000px"/>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,101 +1,121 @@
-# Base image with Python and Conda
-FROM continuumio/miniconda3:latest
+# Curie: Automate Rigorous Scientific Experimentation
 
-# Set the working directory inside the container
-WORKDIR /curie
+[![arXiv](https://img.shields.io/badge/arXiv-2502.16069-b31b1b.svg)](https://arxiv.org/abs/2502.16069)
+[![License](https://img.shields.io/badge/license-Apache_2.0-blue)](LICENSE)
+[![Slack](https://img.shields.io/badge/Slack-Join%20Community-4A154B?logo=slack)](https://join.slack.com/t/just-curieous/shared_invite/zt-313elxhhy-hpEK5r9kX9Xv1Pfxzt9CJQ)
 
-# Set environment variables to avoid interactive prompts
-ENV DEBIAN_FRONTEND=noninteractive
 
-# Update package index and install dependencies
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release \
-    build-essential \
-    vim \
-    make \
-    && rm -rf /var/lib/apt/lists/*
+Curie is the first AI-agent framework designed for automated and rigorous scientific experimentation. 
+Curie helps answer your curiosity through end-to-end experimentation automation, ensuring that every step—from hypothesis formulation to result interpretation—is conducted with precision, reliability, and reproducibility.
+<p align="center">
+  <img src="./docs/static/img/curie-overview.png" width="600px"/>
+</p>
 
-# Install Node.js 20.x and npm
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    apt-get install -y nodejs && \
-    npm install -g npm@latest
+**Key Features**
+- 🚀 Automated Experimentation – End-to-end workflow management: hypothesis formulation, experiment setup, experiment execution, result analysis and finding reflection.
+- 📊 Rigor Enhancement - Built-in verification modules enforce methodical procedure, reliability and interpretability.
+- 🔬 Broad Applicability – Supports ML research, system analysis, and scientific discovery.
+- 📖 Experimentation Benchmark - Provide 46 questions from 4 Computer Science domains, based on influential papers and open-source projects (`benchmark/experimentation_bench`).
 
-# Verify Node.js version
-RUN node --version
+## Table of Contents 
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Use Cases](#use-cases)
+- [Tutorial](#tutorial)
+- [Customize Your Experiment Agents](#customize-your-experimentation-agents) 
 
-# Copy the environment specification
-COPY curie/environment.yml .
+## Installation
 
-# Install micromamba
-ENV MAMBA_ROOT_PREFIX=/opt/micromamba
-ENV PATH=$MAMBA_ROOT_PREFIX/bin:$PATH
+1. Install docker: https://docs.docker.com/engine/install/ubuntu/. 
+Grant permission to docker via `sudo chmod 666 /var/run/docker.sock`. Run `docker ps` to check the permission with the Docker daemon.
 
-RUN arch=$(uname -m) && \
-    if [ "$arch" = "x86_64" ]; then \
-    wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba; \
-    elif [ "$arch" = "aarch64" ]; then \
-    wget -qO- https://micro.mamba.pm/api/micromamba/linux-aarch64/latest | tar -xvj bin/micromamba; \
-    elif [ "$arch" = "ppc64le" ]; then \
-    wget -qO- https://micro.mamba.pm/api/micromamba/linux-ppc64le/latest | tar -xvj bin/micromamba; \
-    else \
-    echo "Unsupported architecture: $arch"; exit 1; \
-    fi && \
-    mv bin/micromamba /usr/local/bin/ && \
-    rmdir bin
+2. Clone the repository:
+```
+git clone https://github.com/Just-Curieous/Curie.git
+cd Curie
+```
 
-# Create base environment with micromamba
-RUN micromamba create -n curie -f environment.yml && \
-    micromamba clean --all --yes
+3. Put your LLM API credentials under `curie/setup/env.sh`. Example: 
 
-ENV MAMBA_DEFAULT_ENV=curie
-ENV PATH=/opt/micromamba/envs/curie/bin:$PATH
+```
+export MODEL="gpt-4o" 
+export OPENAI_API_KEY="sk-xxx" 
+```
 
-RUN micromamba install -y -c conda-forge python=3.12 "nodejs>=20" poetry && micromamba clean --all -y
+4. Build the container image. This will take a few minutes. Note: you may need to setup a virtual environment before running pip install.
 
-# Create the keyrings directory and add Docker's official GPG key
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+```bash
+pip install -e .
+cd curie && docker build --no-cache --progress=plain -t exp-agent-image -f ExpDockerfile_default .. && cd -
+```
 
-# Set up the Docker repository
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
-    | tee /etc/apt/sources.list.d/docker.list > /dev/null
+## Quick Start
+Use the following command to input your research question or problem statement: `python3 -m curie.main -q "<Your research question>"`.
 
-# Update package index again and install Docker Engine
-RUN apt-get update && apt-get install -y \
-    docker-ce \
-    docker-ce-cli \
-    containerd.io \
-    docker-compose-plugin 
+### **Example 1**: Understanding Sorting Algorithm Efficiency
 
-RUN mkdir -p /helper
-# Clone OpenHands repository
-RUN cd /helper && git clone https://github.com/All-Hands-AI/OpenHands.git && cd OpenHands && git checkout 1c7267648327524be3ddfaf4fe340c71c08d845f 
-RUN cd /helper/OpenHands && make build
+```bash
+python3 -m curie.main \
+  -q "How does the choice of sorting algorithm impact runtime performance across different \
+  input distributions (random, nearly sorted, reverse sorted)?" --report
+``` 
 
-# Install additional Python packages using micromamba
-RUN micromamba run -n curie pip install langchain-core==0.3.29 langgraph==0.2.52
+- **Estimated runtime**: ~5 minutes
+- **Sample log file**: Available [here](./docs/example_logs/research_sorting_efficiency_20250310015235.log)
+- **Experiment report**: Available [here](./docs/example_logs/research_sorting_efficiency_20250310015235.md).
+- **Log monitoring**:
+  - Real-time logs are streamed to the console.
+  - Logs are also stored in:
+    - `logs/research_question_<ID>.log` 
+    - `logs/research_question_<ID>_verbose.log`
+  - Experiment report details:
+    - Stored in: `logs/research_question_<ID>.md`
+    - Will only be produced when the `--report` flag is used.
+- **Reproducibility**: The full experimentation process is saved in `workspace/research_<ID>/`.
 
-RUN echo "source /curie/setup/env.sh" >> ~/.bashrc
+## **Example 2**: Find good ML strategies for noisy data.
 
-# Update the Azure configuration
-RUN sed -i '474i \          "organization": "499023",' /root/.cache/pypoetry/virtualenvs/openhands-ai-*-py3.12/lib/python3.12/site-packages/litellm/llms/azure/azure.py
-# To support docker initialization from Curie
-RUN sed -i '237i \                "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},' /helper/OpenHands/openhands/runtime/impl/docker/docker_runtime.py
-RUN sed -i '36i\    user_id = 123 if user_id == 0 else user_id' /helper/OpenHands/openhands/runtime/utils/runtime_init.py
+```bash
+python3 -m curie.main \
+  -q "Are ensemble methods (e.g., Random Forests, Gradient Boosting) more robust to added noise \
+  in the Breast Cancer Wisconsin dataset compared to linear models like Logistic Regression \
+  for a binary classification task?"
+```
 
-# Create necessary directories
-RUN mkdir -p /workspace
+More example questions can be found [here](./docs/quick_start.md).
 
-# Set PATH to activate the Conda environment automatically in the container
-ENV PATH=/opt/micromamba/envs/curie/bin:$PATH
 
-# Ensure bash is the default shell
-SHELL ["/bin/bash", "-c"]
+## Tutorial
+- [How to reproduce the results in `Large Language Monkeys'. ](./docs/tutorial-large-language-monkey.md)
 
-# Keep container running
-CMD ["tail", "-f", "/dev/null"]
+
+## Use Cases
+Curie is designed for scientific discovery across multiple domains:
+
+- 🔬 Machine Learning & AI Research – Hyperparameter tuning and algorithm behavior
+  - [How does the optimal learning rate change with the increase of model size?](https://github.com/microsoft/mup)
+  - [How does repeated sampling in LLM inference affect the quality of response?](https://arxiv.org/abs/2407.21787)
+- 💻 System Performance Analysis – Benchmarking systems, optimizing configurations, investigating system trade-offs.
+  - [What configurations affects the energy consumption of LLM serving?](https://ml.energy/leaderboard/?__theme=light)
+  - [How does the request bursty arrival pattern affects the user experience in LLM serving?](https://arxiv.org/abs/2404.16283)
+- 🧪 Algorithmic & Scientific Discovery – Validating hypotheses, automating computational simulations.
+ 
+<p align="center">
+  <img src="./docs/static/img/case_study.png" width="1000px"/>
+</p>
+
+
+## Customize Your Experimentation Agents
+
+Config `curie/configs/base_config.json` to adapt to your own tasks:  
+- Add your domain-specific instructions by customizing `supervisor_system_prompt_filename` for the supervisor, `control_worker_system_prompt_filename` for the experimentation worker, and so on.
+- Human interruption in the experiment design phase can be activated by setting the `is_user_interrupt_allowed` key to `true`.
+- Configure timeouts and maximum number of steps (global, and coding agent specific).
+
+## Community and Support
+
+For any issues or feature requests, please open an issue on our [GitHub Issues](https://github.com/Just-Curieous/curie/issues) page.
+
+## License
+
+Curie is released under the Apache 2.0 License. See `LICENSE` for more details.

--- a/curie/ExpDockerfile_default
+++ b/curie/ExpDockerfile_default
@@ -49,7 +49,7 @@ RUN arch=$(uname -m) && \
     fi && \
     mv bin/micromamba /usr/local/bin/ && \
     rmdir bin
-    
+
 # Create base environment with micromamba
 RUN micromamba create -n curie -f environment.yml && \
     micromamba clean --all --yes
@@ -76,7 +76,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN mkdir -p /helper
 # Clone OpenHands repository
-RUN cd /helper && git clone https://github.com/All-Hands-AI/OpenHands.git && cd OpenHands && git checkout 1c7267648327524be3ddfaf4fe340c71c08d845f 
+RUN cd /helper && git clone https://github.com/All-Hands-AI/OpenHands.git && cd OpenHands && git checkout 02bc7de36dda10d890d39ac05fee16a0d55193f6
 RUN cd /helper/OpenHands && make build
 
 # Install additional Python packages using micromamba
@@ -85,9 +85,9 @@ RUN micromamba run -n curie pip install langchain-core==0.3.29 langgraph==0.2.52
 RUN echo "source /curie/setup/env.sh" >> ~/.bashrc
 
 # Update the Azure configuration
-RUN sed -i '474i \          "organization": "499023",' /root/.cache/pypoetry/virtualenvs/openhands-ai-*-py3.12/lib/python3.12/site-packages/litellm/llms/azure/azure.py
+RUN sed -i '474i \                    "organization": "499023",' /root/.cache/pypoetry/virtualenvs/openhands-ai-*-py3.12/lib/python3.12/site-packages/litellm/llms/azure/azure.py
 # To support docker initialization from Curie
-RUN sed -i '237i \                "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},' /helper/OpenHands/openhands/runtime/impl/docker/docker_runtime.py
+RUN sed -i '238i \                "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw"},' /helper/OpenHands/openhands/runtime/impl/docker/docker_runtime.py
 RUN sed -i '36i\    user_id = 123 if user_id == 0 else user_id' /helper/OpenHands/openhands/runtime/utils/runtime_init.py
 
 # Create necessary directories

--- a/curie/ExpDockerfile_default
+++ b/curie/ExpDockerfile_default
@@ -37,7 +37,7 @@ RUN conda env create -f environment.yml && \
     conda clean -a && \
     conda init bash && \
     /bin/bash -c "source ~/.bashrc && conda activate curie" 
-    
+
 RUN /opt/conda/bin/conda init bash
 # Install Python and other conda packages
 RUN conda install -y -c conda-forge python=3.12 "nodejs>=20" poetry && conda clean --all -y
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y \
     docker-ce-cli \
     containerd.io \
     docker-compose-plugin 
-    
+
 RUN mkdir -p /helper
 # WORKDIR /helper
 RUN cd /helper && git clone https://github.com/All-Hands-AI/OpenHands.git && cd OpenHands && git checkout 1c7267648327524be3ddfaf4fe340c71c08d845f 

--- a/curie/environment.yml
+++ b/curie/environment.yml
@@ -1,29 +1,30 @@
 name: curie
 channels:
   - defaults
+  - conda-forge
 dependencies:
   - _libgcc_mutex=0.1=main
   - _openmp_mutex=5.1=1_gnu
-  - bzip2=1.0.8=h5eee18b_6
-  - ca-certificates=2024.9.24=h06a4308_0
-  - ld_impl_linux-64=2.40=h12ee557_0
-  - libffi=3.4.4=h6a678d5_1
-  - libgcc-ng=11.2.0=h1234567_1
-  - libgomp=11.2.0=h1234567_1
-  - libstdcxx-ng=11.2.0=h1234567_1
-  - libuuid=1.41.5=h5eee18b_0
-  - ncurses=6.4=h6a678d5_0
-  - openssl=3.0.15=h5eee18b_0
-  - pip=24.2=py311h06a4308_0
-  - python=3.11.10=he870216_0
-  - readline=8.2=h5eee18b_0
-  - setuptools=75.1.0=py311h06a4308_0
-  - sqlite=3.45.3=h5eee18b_0
-  - tk=8.6.14=h39e8969_0
-  - tzdata=2024b=h04d1e81_0
-  - wheel=0.44.0=py311h06a4308_0
-  - xz=5.4.6=h5eee18b_1
-  - zlib=1.2.13=h5eee18b_1
+  - bzip2=1.0.8
+  - ca-certificates=2024.9.24
+  - ld_impl_linux-64
+  - libffi=3.4.4
+  - libgcc-ng=11.2.0
+  - libgomp=11.2.0
+  - libstdcxx-ng=11.2.0
+  - libuuid=1.41.5
+  - ncurses=6.4
+  - openssl=3.0.15
+  - pip=24.2
+  - python=3.11.10
+  - readline=8.2
+  - setuptools=75.1.0
+  - sqlite=3.45.3
+  - tk=8.6.14
+  - tzdata=2024b
+  - wheel=0.44.0
+  - xz=5.4.6
+  - zlib=1.2.13
   - pip:
       - aiofiles==24.1.0
       - aiohappyeyeballs==2.4.4


### PR DESCRIPTION
Modifications made:
1. Previous version specifies the dependent package distribution hash for x86_64 machines docker. However, this cause error when running on arm64 machine (e.g. my Mac M3), the docker image cannot be built. I remove the distribution hash so the docker builder can choose the distribution with more flexibility.
2. In the `ExpDockerfile_default`, I add condition for choosing different micromamba download url based on the host architecture, the same reason above.
After those changes, my mac runs successful reproduction of the sorting algorithm and LLM monkey example on my side.

@patrickkon @AmberLJC Could you help check if this modification works on your machine?