### PR TITLE
add critical fix for starter_file tutorial

### DIFF
--- a/docs/tutorial_with_your_own_starter_file.md
+++ b/docs/tutorial_with_your_own_starter_file.md
@@ -34,11 +34,11 @@ Modify the job configuration file `curie/configs/template.json` to specify your 
 
 ```bash
 cd Curie
-python3 -m curie.main --question_file workspace/my_project/question.txt --task_config curie/configs/template.json 
+python3 -m curie.main --question_file starter_file/my_project/question.txt --task_config curie/configs/template.json 
 ```
 
-- Upon execution, Curie will copy your `my_project` directory into `workspace/my_project_<ID>`, ensuring all modifications occur in a controlled environment.
-
+> [!NOTE]  
+> Upon execution, Curie will copy your `my_project` directory into `workspace/my_project_<ID>`, ensuring all modifications occur in a controlled environment.
 
 ## Customize Curie for Different Tasks
 


### PR DESCRIPTION
---
name: Pull Request 
---
Can @AmberLJC let me know if `workspace` used to work?
`python3 -m curie.main --question_file workspace/random_tests/bplus_test.txt `

This PR does not fully work. Here's why the fix was needed. In the original version using `workspace`, we get this error:
``` bash
~/Curie$ python3 -m curie.main --question_file workspace/random_tests/bplus_test.txt --task_config curie/configs/test_config.json
<frozen runpy>:128: RuntimeWarning: 'curie.main' found in sys.modules after import of package 'curie', but prior to execution of 'curie.main'; this may result in unpredictable behaviour
Curie is running with the following configuration: {'workspace_name': 'random_tests', 'docker_image': 'exp-agent-image', 'dockerfile_name': 'ExpDockerfile_default', 'benchmark_specific_context': 'none', 'is_user_interrupt_allowed': False, 'timeout': 600, 'max_global_steps': 20, 'max_coding_iterations': 20, 'supervisor_system_prompt_filename': 'prompts/exp-supervisor.txt', 'control_worker_system_prompt_filename': 'prompts/controlled-worker.txt', 'exp_group_coding_prompt_filename': 'prompts/exp-group-coding.txt', 'report': False}
2025-03-24 23:24:00 - curie.logger - main.py - INFO - Config file created: logs/configs/random_tests_config_bplus_test_20250324232400_iter1.json
2025-03-24 23:24:00 - curie.logger - main.py - INFO - Check out the log file: logs/bplus_test_20250324232400_iter1.log
2025-03-24 23:24:00 - curie.logger - main.py - INFO - Building Docker image for iteration 1...
2025-03-24 23:24:00 - curie.logger - main.py - INFO - Using existing Docker image: exp-agent-image
2025-03-24 23:24:00 - curie.logger - main.py - INFO - Running Docker container: exp-agent-container-20250324232400-0828d1e6-deac-4f7e-b977-273ee62089f4-iter1
2025-03-24 23:24:00 - curie.logger - main.py - INFO - Running command: docker run -v /var/run/docker.sock:/var/run/docker.sock -v /home/patkon/Curie/curie:/curie:ro -v /home/patkon/Curie/benchmark:/benchmark:ro -v /home/patkon/Curie/logs:/logs -v /home/patkon/Curie/starter_file:/starter_file:ro -v /home/patkon/Curie/workspace:/workspace --network=host -d --name exp-agent-container-20250324232400-0828d1e6-deac-4f7e-b977-273ee62089f4-iter1 exp-agent-image
1beeb839ae02fbc54057850b8ea9c9e5fc6e751d7638802d4eee248e22a1ead3
2025-03-24 23:24:00 - curie.logger - main.py - INFO - Starting experiment in container exp-agent-container-20250324232400-0828d1e6-deac-4f7e-b977-273ee62089f4-iter1 with config in logs/configs/random_tests_config_bplus_test_20250324232400_iter1.json
2025-03-24 23:24:05 - logger - construct_workflow_graph.py - ERROR - Execution error: [Errno 2] No such file or directory: '../workspace/random_tests/bplus_test.txt'
2025-03-24 23:24:05 - logger - construct_workflow_graph.py - ERROR - Execution error: [Errno 2] No such file or directory: '../workspace/random_tests/bplus_test.txt'
Traceback (most recent call last):
  File "/curie/construct_workflow_graph.py", line 512, in main
    valid, user_input = get_question(exp_plan_filename)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/curie/construct_workflow_graph.py", line 427, in get_question
    with open(question_file_path, "r") as question_file:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '../workspace/random_tests/bplus_test.txt'
```


However, with this fix we get this error at the very end of the experiment:

```bash
2025-03-24 23:17:08 - logger - construct_workflow_graph.py - INFO - Event value: The experiment has been concluded with a solid validation of the hypothesis. It demonstrated that full access to the computational graph with OptoPrime (Trace) results in substantial performance improvements compared to both Trace Masked and the Adam optimizer. The evidence gathered is statistically significant and supports the predicted outcome convincingly.
2025-03-24 23:17:08 - logger - scheduler.py - INFO - ------------ Not enough remaining steps to continue with experimentation. Handling concluder output before EXITING!!!------------
2025-03-24 23:17:08 - logger - concluder.py - INFO - ------------ Handle Concluder 🔚 ------------
2025-03-24 23:17:08 - logger - scheduler.py - INFO - <<<<<<<< Scheduling concluder ⏩ __end__ >>>>>>>>
2025-03-24 23:17:08 - logger - construct_workflow_graph.py - ERROR - Execution error: [Errno 30] Read-only file system: '/starter_file/random_tests/bplus_test.txt'
2025-03-24 23:17:08 - logger - construct_workflow_graph.py - ERROR - Execution error: [Errno 30] Read-only file system: '/starter_file/random_tests/bplus_test.txt'
Traceback (most recent call last):
  File "/curie/construct_workflow_graph.py", line 520, in main
    stream_graph_updates(graph, user_input, config)
  File "/curie/construct_workflow_graph.py", line 456, in stream_graph_updates
    for event in graph.stream(
  File "/opt/micromamba/envs/curie/lib/python3.11/site-packages/langgraph/pregel/__init__.py", line 1646, in stream
    for _ in runner.tick(
  File "/opt/micromamba/envs/curie/lib/python3.11/site-packages/langgraph/pregel/runner.py", line 104, in tick
    run_with_retry(t, retry_policy, writer=writer)
  File "/opt/micromamba/envs/curie/lib/python3.11/site-packages/langgraph/pregel/retry.py", line 40, in run_with_retry
    task.proc.invoke(task.input, config)
  File "/opt/micromamba/envs/curie/lib/python3.11/site-packages/langgraph/utils/runnable.py", line 410, in invoke
    input = context.run(step.invoke, input, config, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/micromamba/envs/curie/lib/python3.11/site-packages/langgraph/utils/runnable.py", line 184, in invoke
    ret = context.run(self.func, input, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/curie/scheduler.py", line 111, in SchedNode
    self.write_down_exp_plan()
  File "/curie/scheduler.py", line 150, in write_down_exp_plan
    with open('/'+filename, 'w') as file:
         ^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 30] Read-only file system: '/starter_file/random_tests/bplus_test.txt'
2025-03-24 23:17:08 - curie.logger - main.py - ERROR - Experiment failed with exit code 1. Error: Command '['docker', 'exec', '-it', 'exp-agent-container-20250324230433-e777a144-5c59-4aab-b46d-1b172fc36ae4-iter1', 'bash', '-c', 'source setup/env.sh && eval "$(micromamba shell hook --shell bash)" && micromamba activate curie && python3 construct_workflow_graph.py /logs/configs/random_tests_config_bplus_test_20250324230433_iter1.json']' returned non-zero exit status 1.
2025-03-24 23:17:08 - curie.logger - main.py - ERROR - Experiment failed with exit code 1. Error: Command '['docker', 'exec', '-it', 'exp-agent-container-20250324230433-e777a144-5c59-4aab-b46d-1b172fc36ae4-iter1', 'bash', '-c', 'source setup/env.sh && eval "$(micromamba shell hook --shell bash)" && micromamba activate curie && python3 construct_workflow_graph.py /logs/configs/random_tests_config_bplus_test_20250324230433_iter1.json']' returned non-zero exit status 1.
Stopping and removing Docker container: exp-agent-container-20250324230433-e777a144-5c59-4aab-b46d-1b172fc36ae4-iter1...
exp-agent-container-20250324230433-e777a144-5c59-4aab-b46d-1b172fc36ae4-iter1
exp-agent-container-20250324230433-e777a144-5c59-4aab-b46d-1b172fc36ae4-iter1
Docker container exp-agent-container-20250324230433-e777a144-5c59-4aab-b46d-1b172fc36ae4-iter1 cleaned up.
Running docker: docker container prune -f
Deleted Containers:
bff77c577b63b76ee0969ec239f4da9ad4e4143b17677aea55ea9b701170987f
4a73b500da117a77a31c639aee7972aa5f581fce434a46a3f462e08a5c8090d9
4f7feafc913e1a889482cc0b621c3dec97cdd21bbb1414254338315457f610db

Total reclaimed space: 3.206GB

Running docker: docker image prune -f
Total reclaimed space: 0B

Running docker: docker volume prune -f
Total reclaimed space: 0B

Running docker: docker builder prune -f
Total:  0B

No matching containers found.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/patkon/Curie/curie/main.py", line 277, in <module>
    main() 
    ^^^^^^
  File "/home/patkon/Curie/curie/main.py", line 270, in main
    execute_curie(question_file, unique_id, iteration, task_config)
  File "/home/patkon/Curie/curie/main.py", line 226, in execute_curie
    execute_experiment_in_container(container_name, task_config, config_filename)
  File "/home/patkon/Curie/curie/main.py", line 176, in execute_experiment_in_container
    subprocess.run([
  File "/home/patkon/miniconda3/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['docker', 'exec', '-it', 'exp-agent-container-20250324230433-e777a144-5c59-4aab-b46d-1b172fc36ae4-iter1', 'bash', '-c', 'source setup/env.sh && eval "$(micromamba shell hook --shell bash)" && micromamba activate curie && python3 construct_workflow_graph.py /logs/configs/random_tests_config_bplus_test_20250324230433_iter1.json']' returned non-zero exit status 1.

```


