### PR TITLE
Feature(#55): A better output of Logs

### DIFF
--- a/curie/main.py
+++ b/curie/main.py
@@ -73,10 +73,10 @@ def prune_openhands_docker():
 # Function to create a configuration file
 def create_config_file(question_file, unique_id, iteration, task_config):
     log_dir = 'logs/configs' 
-    experiment_folder = f"logs/{task_config['workspace_name']}_{unique_id}_iter{iteration}"
-    os.makedirs(experiment_folder, exist_ok=True)
-    log_filename = f"{experiment_folder}/{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.log"
-    config_filename = f"{experiment_folder}/{task_config['workspace_name']}_config_{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.json"
+    experiment_log_dir = f"logs/{task_config['workspace_name']}_{unique_id}_iter{iteration}"
+    os.makedirs(experiment_log_dir , exist_ok=True)
+    log_filename = f"{experiment_log_dir }/{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.log"
+    config_filename = f"{experiment_log_dir }/{task_config['workspace_name']}_config_{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.json"
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     task_config.update({"unique_id": unique_id, 
                         "iteration": iteration, 

--- a/curie/main.py
+++ b/curie/main.py
@@ -73,8 +73,12 @@ def prune_openhands_docker():
 # Function to create a configuration file
 def create_config_file(question_file, unique_id, iteration, task_config):
     log_dir = 'logs/configs' 
-    log_filename = f"logs/{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.log"
-    config_filename = f"{log_dir}/{task_config['workspace_name']}_config_{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.json"
+    experiment_folder = f"logs/{task_config['workspace_name']}_{unique_id}_iter{iteration}"
+    os.makedirs(experiment_folder, exist_ok=True)
+    #log_filename = f"logs/{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.log"
+    log_filename = f"{experiment_folder}/{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.log"
+    #config_filename = f"{log_dir}/{task_config['workspace_name']}_config_{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.json
+    config_filename = f"{experiment_folder}/{task_config['workspace_name']}_config_{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.json"
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     task_config.update({"unique_id": unique_id, 
                         "iteration": iteration, 

--- a/curie/main.py
+++ b/curie/main.py
@@ -72,11 +72,10 @@ def prune_openhands_docker():
 
 # Function to create a configuration file
 def create_config_file(question_file, unique_id, iteration, task_config):
-    log_dir = 'logs/configs' 
-    experiment_log_dir = f"logs/{task_config['workspace_name']}_{unique_id}_iter{iteration}"
-    os.makedirs(experiment_log_dir , exist_ok=True)
-    log_filename = f"{experiment_log_dir }/{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.log"
-    config_filename = f"{experiment_log_dir }/{task_config['workspace_name']}_config_{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.json"
+    exp_log_dir = f"logs/{task_config['workspace_name']}_{unique_id}_iter{iteration}"
+    os.makedirs(exp_log_dir , exist_ok=True)
+    log_filename = f"{exp_log_dir }/{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.log"
+    config_filename = f"{exp_log_dir }/{task_config['workspace_name']}_config_{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.json"
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     task_config.update({"unique_id": unique_id, 
                         "iteration": iteration, 

--- a/curie/main.py
+++ b/curie/main.py
@@ -75,9 +75,7 @@ def create_config_file(question_file, unique_id, iteration, task_config):
     log_dir = 'logs/configs' 
     experiment_folder = f"logs/{task_config['workspace_name']}_{unique_id}_iter{iteration}"
     os.makedirs(experiment_folder, exist_ok=True)
-    #log_filename = f"logs/{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.log"
     log_filename = f"{experiment_folder}/{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.log"
-    #config_filename = f"{log_dir}/{task_config['workspace_name']}_config_{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.json
     config_filename = f"{experiment_folder}/{task_config['workspace_name']}_config_{os.path.basename(question_file).replace('.txt', '')}_{unique_id}_iter{iteration}.json"
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     task_config.update({"unique_id": unique_id, 

--- a/curie/reporter.py
+++ b/curie/reporter.py
@@ -50,8 +50,12 @@ def generate_report(config, plan):
     response = model.query_model_safe(messages)
 
     report_name = log_file.split("/")[-1].split(".")[0]
-    with open(f"/logs/{report_name}.md", "w") as file:
+    workspace_name = config["workspace_name"]
+    unique_id = config["unique_id"]
+    iteration = config["iteration"]
+    experiment_folder = f"logs/{workspace_name}_{unique_id}_iter{iteration}"
+    with open(f"/{experiment_folder}/{report_name}.md", "w") as file:
         file.write(response.content)
-    print(f"Report saved to logs/{report_name}.md")
-    return f'logs/{report_name}.md'
+    print(f"Report saved to {experiment_folder}/{report_name}.md")
+    return f"{experiment_folder}/{report_name}.md"
  

--- a/curie/reporter.py
+++ b/curie/reporter.py
@@ -50,9 +50,9 @@ def generate_report(config, plan):
     response = model.query_model_safe(messages)
 
     report_name = log_file.split("/")[-1].split(".")[0]
-    experiment_log_dir = f"logs/{config['workspace_name']}_{config['unique_id']}_iter{config['iteration']}"
-    with open(f"/{experiment_log_dir}/{report_name}.md", "w") as file:
+    exp_log_dir = f"logs/{config['workspace_name']}_{config['unique_id']}_iter{config['iteration']}"
+    with open(f"/{exp_log_dir}/{report_name}.md", "w") as file:
         file.write(response.content)
-    print(f"Report saved to {experiment_log_dir}/{report_name}.md")
-    return f"{experiment_log_dir}/{report_name}.md"
+    print(f"Report saved to {exp_log_dir}/{report_name}.md")
+    return f"{exp_log_dir}/{report_name}.md"
  

--- a/curie/reporter.py
+++ b/curie/reporter.py
@@ -50,12 +50,9 @@ def generate_report(config, plan):
     response = model.query_model_safe(messages)
 
     report_name = log_file.split("/")[-1].split(".")[0]
-    workspace_name = config["workspace_name"]
-    unique_id = config["unique_id"]
-    iteration = config["iteration"]
-    experiment_folder = f"logs/{workspace_name}_{unique_id}_iter{iteration}"
-    with open(f"/{experiment_folder}/{report_name}.md", "w") as file:
+    experiment_log_dir = f"logs/{config['workspace_name']}_{config['unique_id']}_iter{config['iteration']}"
+    with open(f"/{experiment_log_dir}/{report_name}.md", "w") as file:
         file.write(response.content)
-    print(f"Report saved to {experiment_folder}/{report_name}.md")
-    return f"{experiment_folder}/{report_name}.md"
+    print(f"Report saved to {experiment_log_dir}/{report_name}.md")
+    return f"{experiment_log_dir}/{report_name}.md"
  

--- a/curie/tool.py
+++ b/curie/tool.py
@@ -156,10 +156,10 @@ class CodeAgentTool(BaseTool):
                 partition_name=partition_name
             )
             coding_max_iterations = self.config.get("coding_max_iterations", 30)
-            experiment_log_dir = f"logs/{self.config['workspace_name']}_{self.config['unique_id']}_iter{self.config['iteration']}"
+            exp_log_dir = f"logs/{self.config['workspace_name']}_{self.config['unique_id']}_iter{self.config['iteration']}"
             prompt = f'''{system_prompt}\n{prompt}'''
             curie_logger.info(f"👋👋 Trigger Coding Agent.")
-            curie_logger.info(f"🕒 This may take awhile... See log file for details: {experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt")
+            curie_logger.info(f"🕒 This may take awhile... See log file for details: {exp_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt")
 
             # write to a file
             prompt_file = f"../logs/tmp_prompt.txt"
@@ -184,13 +184,13 @@ class CodeAgentTool(BaseTool):
                     f"-f {prompt_file} "
                     f"--config-file ../workspace/config.toml "
                     f"--max-iterations {coding_max_iterations} "
-                    f"2>&1 | tee -a /{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt; "
+                    f"2>&1 | tee -a /{exp_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt; "
                 ]
             })
             # copy the starter file outside the container to the new directory inside the container
             # FIXME: this does not support running outside the container.
             openhands_log = self.extract_codeagent_output_snippet(
-                f"/{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
+                f"/{exp_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
             )
             curie_logger.info(f"💻 Openhands results: {openhands_log}")
         except BaseException as e:
@@ -205,7 +205,7 @@ class CodeAgentTool(BaseTool):
             Re-run the Code Agent with feedback if needed.
 
             {self.extract_codeagent_output_snippet(
-                f"/{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
+                f"/{exp_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
             )}
             """.strip()
         # TODO: return the concise logs.
@@ -329,10 +329,10 @@ class PatcherAgentTool(BaseTool):
 
             )
             
-            experiment_log_dir = f"logs/{self.config['workspace_name']}_{self.config['unique_id']}_iter{self.config['iteration']}"
+            exp_log_dir = f"logs/{self.config['workspace_name']}_{self.config['unique_id']}_iter{self.config['iteration']}"
             prompt = f'''{system_prompt}\n{prompt}'''
             curie_logger.info(f"👋👋 Trigger Coding Patch Agent.")
-            curie_logger.info(f"🕒 This may take awhile... See log file for details: {experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt")
+            curie_logger.info(f"🕒 This may take awhile... See log file for details: {exp_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt")
             # write to a file
             prompt_file = f"../logs/tmp_prompt.txt"
             with open(prompt_file, "w") as file:
@@ -349,12 +349,12 @@ class PatcherAgentTool(BaseTool):
                     f"{chmod_cmd}; "
                     f"export WORKSPACE_BASE={openhands_dir}; "
                     f"export SANDBOX_TIMEOUT=600; " # FIXME: hardcoded timeout
-                    f"/root/.cache/pypoetry/virtualenvs/openhands-ai-*-py3.12/bin/python -m openhands.core.main -f {prompt_file} --config-file ../workspace/config.toml --max-iterations {coding_max_iterations} 2>&1 | tee -a /{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt; " # TODO: create a new file for each openhands log (important to prevnet simultaneous writes in parallel exec situations).
+                    f"/root/.cache/pypoetry/virtualenvs/openhands-ai-*-py3.12/bin/python -m openhands.core.main -f {prompt_file} --config-file ../workspace/config.toml --max-iterations {coding_max_iterations} 2>&1 | tee -a /{exp_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt; " # TODO: create a new file for each openhands log (important to prevnet simultaneous writes in parallel exec situations).
                 ]
             }) 
             # read log
             openhands_log = self.extract_codeagent_output_snippet(
-                f"/{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
+                f"/{exp_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
             )
             curie_logger.info(f"💻 Openhands results: {openhands_log}")
             # copy the starter file outside the container to the new directory inside the container

--- a/curie/tool.py
+++ b/curie/tool.py
@@ -156,10 +156,11 @@ class CodeAgentTool(BaseTool):
                 partition_name=partition_name
             )
             coding_max_iterations = self.config.get("coding_max_iterations", 30)
+            experiment_log_dir = f"logs/{self.config['workspace_name']}_{self.config['unique_id']}_iter{self.config['iteration']}"
             prompt = f'''{system_prompt}\n{prompt}'''
             curie_logger.info(f"👋👋 Trigger Coding Agent.")
-            curie_logger.info(f"🕒 This may take awhile... See log file for details: logs/openhands_{plan_id}_{group}_{partition_name}_logging.txt")
-            
+            curie_logger.info(f"🕒 This may take awhile... See log file for details: {experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt")
+
             # write to a file
             prompt_file = f"../logs/tmp_prompt.txt"
             with open(prompt_file, "w") as file:
@@ -183,13 +184,13 @@ class CodeAgentTool(BaseTool):
                     f"-f {prompt_file} "
                     f"--config-file ../workspace/config.toml "
                     f"--max-iterations {coding_max_iterations} "
-                    f"2>&1 | tee -a /logs/openhands_{plan_id}_{group}_{partition_name}_logging.txt; "
+                    f"2>&1 | tee -a /{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt; "
                 ]
             })
             # copy the starter file outside the container to the new directory inside the container
             # FIXME: this does not support running outside the container.
             openhands_log = self.extract_codeagent_output_snippet(
-                f"/logs/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
+                f"/{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
             )
             curie_logger.info(f"💻 Openhands results: {openhands_log}")
         except BaseException as e:
@@ -204,7 +205,7 @@ class CodeAgentTool(BaseTool):
             Re-run the Code Agent with feedback if needed.
 
             {self.extract_codeagent_output_snippet(
-                f"/logs/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
+                f"/{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
             )}
             """.strip()
         # TODO: return the concise logs.
@@ -328,9 +329,10 @@ class PatcherAgentTool(BaseTool):
 
             )
             
+            experiment_log_dir = f"logs/{self.config['workspace_name']}_{self.config['unique_id']}_iter{self.config['iteration']}"
             prompt = f'''{system_prompt}\n{prompt}'''
             curie_logger.info(f"👋👋 Trigger Coding Patch Agent.")
-            curie_logger.info(f"🕒 This may take awhile... See log file for details: logs/openhands_{plan_id}_{group}_{partition_name}_logging.txt")
+            curie_logger.info(f"🕒 This may take awhile... See log file for details: {experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt")
             # write to a file
             prompt_file = f"../logs/tmp_prompt.txt"
             with open(prompt_file, "w") as file:
@@ -347,12 +349,12 @@ class PatcherAgentTool(BaseTool):
                     f"{chmod_cmd}; "
                     f"export WORKSPACE_BASE={openhands_dir}; "
                     f"export SANDBOX_TIMEOUT=600; " # FIXME: hardcoded timeout
-                    f"/root/.cache/pypoetry/virtualenvs/openhands-ai-*-py3.12/bin/python -m openhands.core.main -f {prompt_file} --config-file ../workspace/config.toml --max-iterations {coding_max_iterations} 2>&1 | tee -a /logs/openhands_{plan_id}_{group}_{partition_name}_logging.txt; " # TODO: create a new file for each openhands log (important to prevnet simultaneous writes in parallel exec situations). 
+                    f"/root/.cache/pypoetry/virtualenvs/openhands-ai-*-py3.12/bin/python -m openhands.core.main -f {prompt_file} --config-file ../workspace/config.toml --max-iterations {coding_max_iterations} 2>&1 | tee -a /{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt; " # TODO: create a new file for each openhands log (important to prevnet simultaneous writes in parallel exec situations).
                 ]
             }) 
             # read log
             openhands_log = self.extract_codeagent_output_snippet(
-                f"/logs/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
+                f"/{experiment_log_dir}/openhands_{plan_id}_{group}_{partition_name}_logging.txt"
             )
             curie_logger.info(f"💻 Openhands results: {openhands_log}")
             # copy the starter file outside the container to the new directory inside the container

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -15,8 +15,8 @@ python3 -m curie.main \
 - **Log monitoring**:
   - Real-time logs are streamed to the console.
   - Logs are also stored in:
-    - `logs/research_question_<ID>.log` 
-    - `logs/research_question_<ID>_verbose.log`.
+    - `logs/research_question_<ID>/research_question_<ID>.log` 
+    - `logs/research_question_<ID>/research_question_<ID>_verbose.log`.
 - **Reproducibility**: The full experimentation process is saved in `workspace/research_<ID>/`.
 
 

--- a/docs/tutorial-large-language-monkey.md
+++ b/docs/tutorial-large-language-monkey.md
@@ -19,6 +19,6 @@ python3 -m curie.main --iterations 1 --question_file benchmark/experimentation_b
 ```
 (We pre-specify the starter file directory name inside `llm_reasoning_config.json`.)
 
-- You can check the logging under `logs/q1_simple_relation_<ID>.log`.
+- You can check the logging under `logs/large_language_monkeys_<ID>/q1_simple_relation_<ID>.log`.
 
 - You can check the reproducible experimentation process under `workspace/large_language_monkeys_<ID>`.


### PR DESCRIPTION
---
name: Pull Request 
---
#55 
**Description**
- Summary:
  Change the path of the logs, config file, openhands, and report, all three types of files will be output to a subfile under /log.

**Expected Behavior**
- Snapshot of Logging Details:
e.g. :
<img width="328" alt="image" src="https://github.com/user-attachments/assets/4747f9af-1928-4324-877f-920f3a5e5aaa" />

**Performance Evaluation**

This PR has been tested using the first quick start example, with the following performance metrics:

- Cost: $0.8851 (with Model: azure/gpt-4o) 
- Correctness:
- Number of Steps: 22
- Execution Time: 541.47 seconds
- Uploaded Log File (Optional):
[research_1744658407_20250414152007_iter1_verbose.log](https://github.com/user-attachments/files/19742353/research_1744658407_20250414152007_iter1_verbose.log)
[research_1744658407_20250414152007_iter1.log](https://github.com/user-attachments/files/19742354/research_1744658407_20250414152007_iter1.log)


